### PR TITLE
Fix background video width flicker on mobile scroll

### DIFF
--- a/app/components/PageComponents/HomePage/homeVideo.tsx
+++ b/app/components/PageComponents/HomePage/homeVideo.tsx
@@ -9,7 +9,7 @@ export default function HomeVideo() {
       loop
       muted
       id="homeVideo"
-      className="bg-static m-auto fixed top-0 left-0 right-0 z-[-1] w-[100vw] h-[100%] tablet:h-auto tablet:-top-80 desktop:h-auto desktop:fixed desktop:-top-96 desktop:z-[-1] wide:top-[-700px]"
+      className="bg-static m-auto fixed top-0 left-0 right-0 z-[-1] w-[100vw] h-[100svh] tablet:h-auto tablet:-top-80 desktop:h-auto desktop:fixed desktop:-top-96 desktop:z-[-1] wide:top-[-700px]"
     >
       <source type="video/webm" src={homeWebM}></source>
       <source type="video/mp4" src={homeMp4}></source>


### PR DESCRIPTION
Switch the homepage video element's mobile height from h-[100%] to
h-[100svh] so it doesn't resize as mobile browsers show/hide the
address bar, which kept rescaling the rendered video and exposing the
TV-static GIF on the sides.

https://claude.ai/code/session_01RpeTykG35zUc1CKxFG77Yo