### PR TITLE
Use object-cover so the homepage video always fills its box

### DIFF
--- a/app/components/PageComponents/HomePage/homeVideo.tsx
+++ b/app/components/PageComponents/HomePage/homeVideo.tsx
@@ -9,7 +9,7 @@ export default function HomeVideo() {
       loop
       muted
       id="homeVideo"
-      className="bg-static m-auto fixed top-0 left-0 right-0 z-[-1] w-[100vw] h-[100%] tablet:h-auto tablet:-top-80 desktop:h-auto desktop:fixed desktop:-top-96 desktop:z-[-1] wide:top-[-700px]"
+      className="bg-static m-auto fixed top-0 left-0 right-0 z-[-1] w-[100vw] h-[100svh] tablet:h-auto tablet:-top-80 desktop:h-auto desktop:fixed desktop:-top-96 desktop:z-[-1] wide:top-[-700px]"
     >
       <source type="video/webm" src={homeWebM}></source>
       <source type="video/mp4" src={homeMp4}></source>

--- a/app/components/PageComponents/HomePage/homeVideo.tsx
+++ b/app/components/PageComponents/HomePage/homeVideo.tsx
@@ -9,7 +9,7 @@ export default function HomeVideo() {
       loop
       muted
       id="homeVideo"
-      className="bg-static m-auto fixed top-0 left-0 right-0 z-[-1] w-[100vw] h-[100svh] tablet:h-auto tablet:-top-80 desktop:h-auto desktop:fixed desktop:-top-96 desktop:z-[-1] wide:top-[-700px]"
+      className="bg-static object-cover m-auto fixed top-0 left-0 right-0 z-[-1] w-[100vw] h-[100svh] tablet:h-auto tablet:-top-80 desktop:h-auto desktop:fixed desktop:-top-96 desktop:z-[-1] wide:top-[-700px]"
     >
       <source type="video/webm" src={homeWebM}></source>
       <source type="video/mp4" src={homeMp4}></source>


### PR DESCRIPTION
## Summary
- Follow-up to #105: that fix (`h-[100svh]`) wasn't enough on DuckDuckGo's mobile browser — the static GIF still flashed on the sides during scroll.
- Root cause: `B2L-Loop` is a portrait video (720x1280, 9:16). Inside a portrait phone viewport, the default contain-fit can be either width- or height-constrained, and that constraint flips as the address bar shows/hides, so the rendered video width changes and exposes `bg-static` on the sides.
- Adding `object-cover` forces the `<video>` to fill its element box, so the visible width is always `100vw` regardless of how the height behaves. `tablet:`/`desktop:` use `h-auto` (box already matches the video's aspect ratio), so they're unaffected.

## Test plan
- [x] On mobile DuckDuckGo, scroll up and down on the homepage; the video edges stay flush to the screen edges and no TV static appears at the sides.
- [x] Repeat in mobile Safari and mobile Chrome.
- [x] Tablet (>=760px) and desktop (>=950px) layouts look unchanged (video sized by `h-auto`, with intentional static showing below the offset).
- [x] 404 page (`/some-missing-route`) renders normally.

https://claude.ai/code/session_01RpeTykG35zUc1CKxFG77Yo

---
_Generated by [Claude Code](https://claude.ai/code/session_01RpeTykG35zUc1CKxFG77Yo)_