### PR TITLE
Fix mobile footer disappearing on scroll (sticky + height revert)

### DIFF
--- a/app/components/PageComponents/HomePage/homeVideo.tsx
+++ b/app/components/PageComponents/HomePage/homeVideo.tsx
@@ -9,7 +9,7 @@ export default function HomeVideo() {
       loop
       muted
       id="homeVideo"
-      className="bg-static object-cover m-auto fixed top-0 left-0 right-0 z-[-1] w-[100vw] h-[100svh] tablet:h-auto tablet:-top-80 desktop:h-auto desktop:fixed desktop:-top-96 desktop:z-[-1] wide:top-[-700px]"
+      className="bg-static object-cover m-auto fixed top-0 left-0 right-0 z-[-1] w-[100vw] h-[100%] tablet:h-auto tablet:-top-80 desktop:h-auto desktop:fixed desktop:-top-96 desktop:z-[-1] wide:top-[-700px]"
     >
       <source type="video/webm" src={homeWebM}></source>
       <source type="video/mp4" src={homeMp4}></source>


### PR DESCRIPTION
## Summary
Two-part fix following PRs #105/#106. After the side-flicker fix shipped, the footer was disappearing during scroll on iOS Safari and only reappearing once the user scrolled to the very bottom of the page.

### Root cause
The footer is `position: fixed; bottom: 0`. On iOS Safari, fixed-bottom elements anchor to the *layout* viewport — so when the address bar animates back in during scroll, the footer slides under it and only re-emerges when the scroll bottoms out (and the address bar collapses again). The `h-[100svh]` introduced in #105 made the gap obvious because the video element shrank with the address bar; the previous `h-[100%]` was visually masking the same iOS quirk.

### Changes
1. **`homeVideo.tsx`** — revert `h-[100svh]` back to `h-[100%]`. `object-cover` (added in #106) is what actually fixes the side-flicker; the height change isn't needed.
2. **`Footer/index.tsx`** — switch `position: fixed` → `position: sticky` (`bottom: 0`). `sticky` resolves against the visual viewport / scroll container instead of the layout viewport, so the footer stays in view across address-bar transitions.
3. **`tailwind.css`** — add `min-height: 100dvh` to `body` so short pages (e.g. the 404 route) still have enough flow height to push the sticky footer to the bottom of the viewport rather than leaving it floating mid-page.

Net diff vs the pre-#105 state on the video: `+ object-cover`. Footer changes are independent and address a pre-existing iOS quirk that #105 inadvertently exposed.

## Test plan
- [ ] On mobile DuckDuckGo / Safari, scroll up and down on the homepage:
  - [ ] Video edges stay flush to screen sides (no static).
  - [ ] Footer's social icons remain fully visible at the bottom throughout scroll, including while the address bar is animating in/out.
- [ ] Tablet (>=760px) and desktop (>=950px) layouts unchanged.
- [ ] 404 page (`/some-missing-route`) — footer sits at the bottom of the viewport (not floating in the middle).
- [ ] Tall pages (Shows, Subscribe sections) — content still scrolls normally; footer doesn't overlap with the page's existing bottom spacer in a jarring way.

https://claude.ai/code/session_01RpeTykG35zUc1CKxFG77Yo