### PR TITLE
Fix mobile side-flicker without breaking the DDG footer

### DIFF
--- a/app/components/PageComponents/HomePage/homeVideo.tsx
+++ b/app/components/PageComponents/HomePage/homeVideo.tsx
@@ -3,16 +3,22 @@ import homeMp4 from "../../../assets/B2L-Loop.mp4";
 
 export default function HomeVideo() {
   return (
-    <video
-      playsInline
-      autoPlay
-      loop
-      muted
-      id="homeVideo"
-      className="bg-static m-auto fixed top-0 left-0 right-0 z-[-1] w-[100vw] h-[100%] tablet:h-auto tablet:-top-80 desktop:h-auto desktop:fixed desktop:-top-96 desktop:z-[-1] wide:top-[-700px]"
-    >
-      <source type="video/webm" src={homeWebM}></source>
-      <source type="video/mp4" src={homeMp4}></source>
-    </video>
+    <>
+      <div
+        aria-hidden="true"
+        className="bg-static fixed inset-0 z-[-2] tablet:hidden"
+      ></div>
+      <video
+        playsInline
+        autoPlay
+        loop
+        muted
+        id="homeVideo"
+        className="bg-static m-auto fixed top-0 left-0 right-0 z-[-1] w-[100vw] aspect-[9/16] tablet:h-auto tablet:aspect-auto tablet:-top-80 desktop:h-auto desktop:fixed desktop:-top-96 desktop:z-[-1] wide:top-[-700px]"
+      >
+        <source type="video/webm" src={homeWebM}></source>
+        <source type="video/mp4" src={homeMp4}></source>
+      </video>
+    </>
   );
 }

--- a/app/components/PageComponents/HomePage/homeVideo.tsx
+++ b/app/components/PageComponents/HomePage/homeVideo.tsx
@@ -9,7 +9,7 @@ export default function HomeVideo() {
       loop
       muted
       id="homeVideo"
-      className="bg-static object-cover m-auto fixed top-0 left-0 right-0 z-[-1] w-[100vw] h-[100%] tablet:h-auto tablet:-top-80 desktop:h-auto desktop:fixed desktop:-top-96 desktop:z-[-1] wide:top-[-700px]"
+      className="bg-static m-auto fixed top-0 left-0 right-0 z-[-1] w-[100vw] h-[100%] tablet:h-auto tablet:-top-80 desktop:h-auto desktop:fixed desktop:-top-96 desktop:z-[-1] wide:top-[-700px]"
     >
       <source type="video/webm" src={homeWebM}></source>
       <source type="video/mp4" src={homeMp4}></source>


### PR DESCRIPTION
## Summary
One PR, both fixes: the homepage `<video>` no longer flickers on mobile scroll, **and** the fixed footer keeps working in DuckDuckGo's mobile browser. No `object-cover`, no `svh`/`dvh` units — both of those triggered cross-browser inconsistencies in earlier attempts (#105-#107).

## Approach
Two commits on the branch:

1. **`a74219d` — Remove `object-cover`.** Restores cross-browser consistency. On its own, the original side-flicker would return — but the next commit fixes that with a different mechanism.
2. **`f724aa7` — Aspect-ratio + backdrop.** Matches the `<video>` element's CSS `aspect-ratio` to the source's intrinsic 720x1280 (9:16), so default `object-fit: contain` fills the box exactly with no letterbox bars and nothing to flicker. A mobile-only `bg-static` backdrop `<div>` sits behind the video to fill the ~150px of viewport below the 9:16 box on portrait phones (mirrors the existing 404-page pattern).

`tablet:aspect-auto` is required alongside the existing `tablet:h-auto`: without it, the explicit `9/16` from the base class would still apply at tablet+ and override the video's intrinsic ratio, breaking the tuned `-top-80` / `-top-96` / `top-[-700px]` offsets.

## Why this won't recur the DDG footer bug
The DDG regression in #106 was specific to `object-fit: cover` interacting with WKWebView's scroll-driven layout updates. This fix uses CSS `aspect-ratio` for sizing and leaves `object-fit` at the default `contain` — a different layout code path with no known DDG quirks. The footer is untouched.

## Known trade-off
On mobile there's now a horizontal seam at `~y = 100vw × 16/9` (≈694px on a 390-wide phone) where the video's bottom edge meets the static backdrop. Unlike the original side bars, this seam is fixed in place during scroll (no flicker), and uses the same `bg-static` aesthetic already established on the 404 page.

## Test plan
- [ ] **Mobile DuckDuckGo:** scroll up and down on the homepage.
  - [ ] No TV-static flicker on the sides.
  - [ ] Footer's social icons stay fully visible at the bottom throughout scroll, including while the DDG bottom toolbar animates in/out.
- [ ] **Mobile Safari + Chrome:** same — no flicker, footer stable.
- [ ] **Tablet (>=760px) and desktop (>=950px):** layout looks identical to current `main` (the `tablet:aspect-auto` + `tablet:h-auto` pair preserves today's offset layout).
- [ ] **404 page (`/some-missing-route`):** unchanged.
- [ ] **Slow network sanity check:** with DevTools throttling at "Slow 3G", confirm no obvious flash before video metadata loads (backdrop should mask any pre-metadata letterboxing anyway).

https://claude.ai/code/session_01RpeTykG35zUc1CKxFG77Yo