### PR TITLE
Revert homepage video to pre-#105 state

### DIFF
--- a/app/components/PageComponents/HomePage/homeVideo.tsx
+++ b/app/components/PageComponents/HomePage/homeVideo.tsx
@@ -3,22 +3,16 @@ import homeMp4 from "../../../assets/B2L-Loop.mp4";
 
 export default function HomeVideo() {
   return (
-    <>
-      <div
-        aria-hidden="true"
-        className="bg-static fixed inset-0 z-[-2] tablet:hidden"
-      ></div>
-      <video
-        playsInline
-        autoPlay
-        loop
-        muted
-        id="homeVideo"
-        className="bg-static m-auto fixed top-0 left-0 right-0 z-[-1] w-[100vw] aspect-[9/16] tablet:h-auto tablet:aspect-auto tablet:-top-80 desktop:h-auto desktop:fixed desktop:-top-96 desktop:z-[-1] wide:top-[-700px]"
-      >
-        <source type="video/webm" src={homeWebM}></source>
-        <source type="video/mp4" src={homeMp4}></source>
-      </video>
-    </>
+    <video
+      playsInline
+      autoPlay
+      loop
+      muted
+      id="homeVideo"
+      className="bg-static m-auto fixed top-0 left-0 right-0 z-[-1] w-[100vw] h-[100%] tablet:h-auto tablet:-top-80 desktop:h-auto desktop:fixed desktop:-top-96 desktop:z-[-1] wide:top-[-700px]"
+    >
+      <source type="video/webm" src={homeWebM}></source>
+      <source type="video/mp4" src={homeMp4}></source>
+    </video>
   );
 }


### PR DESCRIPTION
## Summary
Roll back the #105–#108 series of attempted homepage video fixes. None produced acceptable behavior on mobile DuckDuckGo, and #108 still showed the footer flying off-screen on scroll instead of sticking to the viewport.

Restores `app/components/PageComponents/HomePage/homeVideo.tsx` to its exact pre-#105 content. Verified empty diff vs the commit immediately before #105 (`a3ff2dc^`).

The original side-flicker bug returns by design — that's the accepted trade-off in exchange for the consistent cross-browser behavior the site had before this whole series.

## Confirmation: PR #104 (ticket link parsing) is unaffected
Verified that `git diff a3ff2dc^..origin/main -- app/components/PageComponents/Shows/` returns no output. The Shows directory (where #104's ticket-parsing fix lives — `Event.tsx` and `formatters.tsx`) was not touched by any of #105 through #108. This revert only modifies `homeVideo.tsx`, so the ticket-link fix stays fully intact.

## Test plan
- [ ] **Mobile DuckDuckGo, Safari, Chrome:** behavior matches what it was before any of #105–#108. Side-flicker present (expected); footer behavior consistent across browsers as it was originally.
- [ ] **Tablet (>=760px) and desktop (>=950px):** unchanged.
- [ ] **Shows / "BUY TICKETS" links:** clicking through a ticket link still goes to the correct destination (i.e. the #104 fix still works).
- [ ] **404 page (`/some-missing-route`):** unchanged.

https://claude.ai/code/session_01RpeTykG35zUc1CKxFG77Yo

---
_Generated by [Claude Code](https://claude.ai/code/session_01RpeTykG35zUc1CKxFG77Yo)_